### PR TITLE
[Chore] LMS_CLIENT 토큰 Symbol로 통일

### DIFF
--- a/passion-load-service/src/common/clients/lms/lms.token.ts
+++ b/passion-load-service/src/common/clients/lms/lms.token.ts
@@ -1,1 +1,1 @@
-export const LMS_CLIENT = 'LMS_CLIENT';
+export const LMS_CLIENT = Symbol('LMS_CLIENT');


### PR DESCRIPTION
# 작업 내용

### LMS_CLIENT 토큰 Symbol로 통일

- Repository 토큰은 `Symbol`을 사용하는 반면 `LMS_CLIENT`만 문자열을 사용하여 일관성이 없는 문제 해결
- 문자열 토큰은 다른 모듈과 이름 충돌 가능성이 있으므로 `Symbol`로 변경

### lms.token.ts 수정

- `export const LMS_CLIENT = 'LMS_CLIENT'` → `export const LMS_CLIENT = Symbol('LMS_CLIENT')`

# 체크리스트

- [x] `lms.token.ts` Symbol로 변경
- [x] CI 통과 확인

---

Closes #44