### PR TITLE
[Chore] 피드백 content 250자 제한 백엔드에서 제거

### DIFF
--- a/passion-load-service/src/modules/feedback/adapters/in/feedback.dto.ts
+++ b/passion-load-service/src/modules/feedback/adapters/in/feedback.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class CreateFeedbackDto {
   @ApiProperty({ example: 'student_123' })
@@ -12,11 +12,9 @@ export class CreateFeedbackDto {
   assignmentId?: string;
 
   @ApiProperty({
-    maxLength: 250,
     example: '오늘 과제 수행이 좋아요. 다음 단계로 넘어가도 됩니다.',
   })
   @IsString()
-  @MaxLength(250)
   content!: string;
 }
 

--- a/passion-load-service/src/modules/feedback/feedback.service.ts
+++ b/passion-load-service/src/modules/feedback/feedback.service.ts
@@ -27,9 +27,6 @@ export class FeedbacksService {
   ) {
     if (!teacherId) throw new BadRequestException('teacherId is required');
 
-    if (dto.content.length > 250)
-      throw new BadRequestException('content must be <= 250 length');
-
     if (dto.assignmentId) {
       await this.assignmentUseCase.validateAssignment(orgId, dto.assignmentId);
     }

--- a/passion-load-service/src/modules/feedback/feedbacks.service.spec.ts
+++ b/passion-load-service/src/modules/feedback/feedbacks.service.spec.ts
@@ -37,16 +37,8 @@ describe('FeedbacksService (UseCase unit)', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('content 250자 초과면 실패', async () => {
-    const long = 'a'.repeat(251);
-    await expect(
-      service.create('org1', 't1', { studentId: 's1', content: long })
-    ).rejects.toBeInstanceOf(BadRequestException);
-  });
-
   it('assignmentId가 다른 org의 데이터면 실패', async () => {
     assignmentUseCase.validateAssignment.mockRejectedValue(
-      // 변경
       new NotFoundException('assignment not found')
     );
 
@@ -60,7 +52,7 @@ describe('FeedbacksService (UseCase unit)', () => {
   });
 
   it('정상 생성', async () => {
-    assignmentUseCase.validateAssignment.mockResolvedValue(undefined); // 변경
+    assignmentUseCase.validateAssignment.mockResolvedValue(undefined);
     feedbackRepo.create.mockResolvedValue({ id: 'f1' });
 
     const res = await service.create('org1', 't1', {


### PR DESCRIPTION
# 작업 내용

### 피드백 content 250자 제한 백엔드에서 제거

- 250자 이상이어야 저장 가능한 UX 요구사항에 따라 검증 주체를 프론트로 이전
- 백엔드에서 제한하면 프론트 정책과 충돌하는 문제 해결

### feedback.service.ts 수정

- `dto.content.length > 250` 검증 로직 제거

### feedback.dto.ts 수정

- `@MaxLength(250)` 데코레이터 제거
- `maxLength: 250` Swagger 명세 제거
- `MaxLength` import 제거

### feedbacks.service.spec.ts 수정

- `content 250자 초과면 실패` 테스트 케이스 제거

# 체크리스트

- [x] `feedback.service.ts` 검증 로직 제거
- [x] `feedback.dto.ts` MaxLength 제거
- [x] `feedbacks.service.spec.ts` 테스트 케이스 제거
- [x] CI 통과 확인